### PR TITLE
Update slashing params

### DIFF
--- a/technical-reference/validators/slashing.md
+++ b/technical-reference/validators/slashing.md
@@ -8,7 +8,7 @@ Canto implements the [Cosmos SDK slashing module](https://docs.cosmos.network/ma
 
 ## Downtime Slashing
 
-Downtime slashing occurs when a validator fails to sign 2160 consecutive blocks, which corresponds to approximately three hours of downtime.
+Downtime slashing occurs when a validator fails to sign 3000 consecutive blocks, which corresponds to approximately three hours of downtime.
 
 As a penalty for downtime, validators are:
 
@@ -21,7 +21,7 @@ Consensus fault slashing occurs when a validator commits any kind of consensus f
 
 As a penalty for consensus faults, validators are:
 
-* slashed by **4%**
+* slashed by **5%**
 * **tombstoned** (infinitely jailed)
 
 {% hint style="danger" %}


### PR DESCRIPTION
Update slashing params to match what I see when running `cantod query slashing params` on my validator

![Screen Shot 2022-11-03 at 10 47 38 AM](https://user-images.githubusercontent.com/5386588/199753660-13363cb7-888c-4adb-9732-c181114ecca6.png)
