### PR TITLE
🥢 Nit: Use `tx.origin` for Turnstile example

### DIFF
--- a/evm-development/contract-secured-revenue.md
+++ b/evm-development/contract-secured-revenue.md
@@ -31,7 +31,7 @@ contract Example {
     constructor() {
         //Registers the smart contract with Turnstile
         //Mints the CSR NFT to the contract creator
-        turnstile.register(msg.sender);
+        turnstile.register(tx.origin);
     }
 }
 ```


### PR DESCRIPTION
use `tx.origin` as example for turnstile `register()` because `msg.sender` seems to opinionated to contract itself being recipient of fees which seems problematic for claiming unless contract also implements that method with recipient.