### PR TITLE
Update to canto bridge guide

### DIFF
--- a/user-guides/bridging-assets/to-canto.md
+++ b/user-guides/bridging-assets/to-canto.md
@@ -16,10 +16,16 @@ At present, the Ethereum <-> Canto bridge supports ETH, USDC, and USDT transfers
 
 Assets bridged to Canto will arrive on the native Canto blockchain 96 ETH blocks (20 minutes) after the Ethereum transfer is confirmed. If you want to use the Canto Lending Market, Canto DEX, and other DApps, you must [bridge your assets to the Canto EVM](bridge-vs-evm.md).
 
-## From Cosmos Hub
+## From Cosmos Hub or other IBC enabled chain
 
 {% hint style="danger" %}
-**Do not attempt to transfer $ATOM to the Canto address in your Keplr wallet. Follow the instructions below.**
+**Do not attempt to transfer $ATOM or any other token to the Canto address in your Keplr wallet. Follow the instructions below.**
+{% endhint %}
+
+This section covers bridging to Canto using Keplr, while $ATOM from the Cosmos Hub is used as an example this guide will also work for SOMM, GRAV, AKT, OSMO, INJ, CMDX, KAVA, and CRE
+
+{% hint style="danger" %}
+**Do not attempt to transfer any token that is not on the above list to Canto via IBC**
 {% endhint %}
 
 To bridge $ATOM from the Cosmos Hub network to the Canto Network, follow these steps:
@@ -38,11 +44,23 @@ To bridge $ATOM from the Cosmos Hub network to the Canto Network, follow these s
 
 ![](<../../.gitbook/assets/Screen Shot 2022-08-19 at 1.34.54 PM.png>)
 
-6\. In Keplr, switch to the Cosmos Hub. Then click IBC Transfer.
+6\. In Keplr, switch to the Cosmos Hub, or the chain you are trying to bridge from. Then click IBC Transfer.
 
 ![](<../../.gitbook/assets/image (13).png>)
 
-7\. Select “Canto Mainnet” as the destination chain. If bridging for the first time, add Canto by clicking "New IBC Transfer Channel", selecting Canto Mainnet and entering `channel-358.`
+7\. Select “Canto Mainnet” as the destination chain. If bridging for the first time, add Canto by clicking "New IBC Transfer Channel", selecting Canto Mainnet. Then enter the correct channel depending on the chain you are bridging from.
+
+| Source Chain   | Channel     |
+| -------------- | ----------- |
+| Cosmos Hub     | channel-358 |
+| Gravity Bridge | channel-88  |
+| Kava           | channel-87  |
+| Akash          | channel-59  |
+| Osmosis        | channel-550 |
+| Injective      | channel-99  |
+| Comdex         | channel-58  |
+| Crescent       | channel-34  |
+| Sommelier      | channel-2   |
 
 ![](<../../.gitbook/assets/image (19).png>)![](<../../.gitbook/assets/image (2).png>)
 
@@ -51,33 +69,3 @@ To bridge $ATOM from the Cosmos Hub network to the Canto Network, follow these s
 ![](<../../.gitbook/assets/image (4).png>)
 
 Assets bridged to Canto will arrive on the Canto Bridge blockchain. If you want to use the Canto Lending Market, Canto DEX, and other DApps, you must [bridge your assets to the Canto EVM](bridge-vs-evm.md).
-
-## From Gravity Bridge
-
-{% hint style="danger" %}
-**Do not attempt to transfer Gravity tokens to the Canto address in your Keplr wallet. Follow the instructions below.**
-{% endhint %}
-
-To bridge assets from Gravity Bridge to the Canto network, follow these steps:
-
-1. Navigate to [**canto.io/bridge**](https://canto.io/bridge) **** and connect your MetaMask wallet, making sure you are on the Ethereum network.
-2. Before bridging to Canto, **generate a Canto public key** by clicking on the red banner at the top of the page and signing the transaction in your wallet.
-3. In the sidebar, click the `add to keplr` button:
-
-<figure><img src="../../.gitbook/assets/add-to-keplr-new (1).png" alt=""><figcaption></figcaption></figure>
-
-4\. Copy your Canto native address:
-
-<figure><img src="../../.gitbook/assets/canto-native-address-new.png" alt=""><figcaption></figcaption></figure>
-
-5\. Navigate to [**bridge.blockscape.network**](https://bridge.blockscape.network) and connect your Keplr wallet
-
-6\. Select Gravity Bridge as the source chain and Canto as the destination chain:
-
-7\. Connect your Gravity Keplr wallet. _Do not_ connect Keplr to Canto instead, click the lock icon under `transfer address` and paste your Canto native address there.
-
-8\. Select the token you would like to bridge and input the quantity. Quantities less than 1 must include a 0 in the ones place value (e.g. `0.99`).
-
-9\. Sign the message in your wallet to confirm the transfer.
-
-Assets bridged to Canto will arrive on the native Canto blockchain within 60 seconds of the Gravity Bridge transaction being confirmed. If you want to use the Canto Lending Market, Canto DEX, and other DApps, you must [convert your assets to the Canto EVM](broken-reference).


### PR DESCRIPTION
This commit updates the bridge guide to canto by modifying the Atom bridging guide to include all currently connected IBC chains and removing Gravity which can also be folded under the IBC chain category.

The goal here is to reduce the total amount of documentation while also supporting many future IBC chains that are not yet added. Simply duplicating the documentation for each chain would quickly become impractical.